### PR TITLE
修改package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiss",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "a better solution for front-end based on fis3",
   "main": "index.js",
   "bin": {
@@ -30,7 +30,10 @@
     "fis3": "^3.3.16",
     "liftoff": "^2.2.0",
     "minimist": "^1.2.0",
-    "fiss-command-init": "^1.1.0",
-	  "fiss-command-release":"*"
+    "fiss-command-init": "1.2.0",
+    "fiss-command-release":"*",
+    "fis-lint-html-hint": "^1.0.0",
+    "fiss-lint-csslint": "^1.0.0",
+    "fiss-lint-eslint": "^1.0.0"
   }
 }


### PR DESCRIPTION
升级fiss-command-init的版本
把lint的模块作为fiss的默认依赖
升级版本号到1.0.4
